### PR TITLE
Convert PostbackScript to list from binary before concatination.

### DIFF
--- a/src/nitrogen/actions/action_api.erl
+++ b/src/nitrogen/actions/action_api.erl
@@ -7,5 +7,5 @@ render_action(Record) ->
     Name = Record#api.name,
     Data = "utf8_toByteArray(JSON.stringify(data))",
     PostbackScript = wf_event:new(Name, "document", Record#api.delegate, api_event, Data, []),
-    wf:f("~s = function(data) {",  [Name]) ++ PostbackScript ++ "};".
+    wf:f("~s = function(data) {",  [Name]) ++ binary_to_list(PostbackScript) ++ "};".
 


### PR DESCRIPTION
#api_event isn't working because of this issue. Please review and accept if appropriate. Thanks.