### PR TITLE
nitrogen.js/fieldset: fix error when ids contain special characters

### DIFF
--- a/priv/protocols/nitrogen.js
+++ b/priv/protocols/nitrogen.js
@@ -4,7 +4,7 @@ function querySourceRaw(Id) {
     var val, el = document.getElementById(Id);
     if (!el) return "";
     switch (el.tagName) {
-        case 'FIELDSET': val = document.querySelector('#' + Id + ' :checked');
+        case 'FIELDSET': val = document.querySelector('[id="' + Id + '"] :checked');
                          val = val ? val.value : ""; break;
         case 'INPUT':
             switch (el.getAttribute("type")) {
@@ -24,4 +24,3 @@ function querySource(Id) {
     var qs = querySourceRaw(Id);
     if(qs instanceof Date) { return tuple(number(qs.getFullYear()),number(qs.getMonth()+1),number(qs.getDate())); }
     else { return utf8_toByteArray(qs); } }
-


### PR DESCRIPTION
FIX: SyntaxError: DOM Exception 12: An invalid or illegal string was specified.