### PR TITLE
Update cx to match nitro cx

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -2,8 +2,8 @@
 -define(N2O_HRL, true).
 
 -record(handler, { name, module, class, group, config, state}).
--record(cx,      { handlers, actions, req, module, lang, path, session, formatter=false, params, form, state=[] }).
-
+-record(cx,      { handlers=[], actions=[], req=[], module=[], lang=[], path=[],
+                   session=[], formatter=false, params=[], node=[], client_pid=[], state=[], from=[], vsn = [] }).
 -define(CTX, (get(context))).
 -define(REQ, (get(context))#cx.req).
 


### PR DESCRIPTION
Then we can use nitro master for the non-mqtt n2o.