### PR TITLE
Update n2o_vnode and small fixing n2o 

### DIFF
--- a/src/n2o.erl
+++ b/src/n2o.erl
@@ -31,7 +31,7 @@ start(_,_) -> catch n2o_vnode:load([]), X = supervisor:start_link({local,n2o},n2
                 X.
 
 start_mqtt_ring() ->
-  [ n2o_pi:start(#pi{module=n2o_vnode,table=mqtt,sup=n2o,state=[],name=Pos})
+  [ n2o_pi:start(#pi{module=n2o_vnode,table=ring,sup=n2o,state=[],name=Pos})
  || {{_,_},Pos} <- lists:zip(ring(),lists:seq(1,length(ring()))) ].
 
 start_ws_ring() ->


### PR DESCRIPTION
Now we can consider as acceptable events-topics for example the following types:
<<"events/1/2/api/anon/emqttd_lx9tr6mfwwjuob3bn6/">> and 
<<"events/1/2/api/anon/emqttd_lx9tr6mfwwjuob3bn6">>; 
<<"events/1/2/api/anon/emqttd_lx9tr6mfwwjuob3bn6/Token">>
and  <<"events/1/2/api/anon/emqttd_lx9tr6mfwwjuob3bn6/Token/">>
but as unacceptable:
<<"events/1/2/api/anon/>>, <<"events/1/2/api//>> etc

so we need to update n2o_vnode.

There is small fix  to  start vnode  just after n2o start too.