### PR TITLE
Page WS Terminate event

### DIFF
--- a/src/ws/n2o_cowboy2.erl
+++ b/src/ws/n2o_cowboy2.erl
@@ -18,6 +18,7 @@ ws(X) -> ?LOG_ERROR(#{unknown=>X}), {shutdown,[]}.
 websocket_init(S)            -> ws(n2o_proto:init([],S,[],ws)).
 websocket_handle(D,S)        -> ws(n2o_proto:stream(D,[],S)).
 websocket_info(D,S)          -> ws(n2o_proto:info(D,[],S)).
+terminate(M,R,S)             -> ws(n2o_proto:info(#direct{data={exit,M}},R,S)).
 
 points() -> cowboy_router:compile([{'_', [
 	    {"/ws/[...]", n2o_cowboy2, []},


### PR DESCRIPTION
Similar as Mod:event(init), there is a need for a hook to Mod:event({exit,Reason}) to perform certain actions if browser (Tab,Page) gets closed.