### PR TITLE
Set new filepath value in #FTP record on init

### DIFF
--- a/src/protos/n2o_ftp.erl
+++ b/src/protos/n2o_ftp.erl
@@ -34,7 +34,7 @@ info(#ftp{id = Link, status = <<"init">>, block = Block, offset = Offset}=FTP, R
 
     Block2 = case Block of 0 -> ?STOP; _ -> ?NEXT end,
     Offset2 = case FileSize >= Offset of true -> FileSize; false -> 0 end,
-    FTP2 = FTP#ftp{block = Block2, offset = Offset2, data = <<>>},
+    FTP2 = FTP#ftp{block = Block2, offset = Offset2, data = <<>>, filename=FilePath},
 
     catch n2o_pi:stop(file, Link),
     n2o_pi:start(#pi{module=?MODULE, table=file, sup=n2o, state=FTP2, name=Link}),


### PR DESCRIPTION
File is otherwise uploaded into the root upload directory, ignoring path set in :25

RelPath=(application:get_env(n2o,filename,n2o_ftp)):filename(FTP),