### PR TITLE
Resolve unused variable warnings

### DIFF
--- a/src/n2o_multipart.erl
+++ b/src/n2o_multipart.erl
@@ -18,7 +18,7 @@ stream_body(Req0, Acc) ->
 init(Req, Opts) ->
     {ok, Body, Req2} = acc_multipart(Req, []),
     {Headers, Data} = hd(Body),
-    {file, _, Filename, ContentType} = cow_multipart:form_data(Headers),
+    {file, _, _Filename, _ContentType} = cow_multipart:form_data(Headers),
     GUID = erp:guid(),
     Size = erlang:integer_to_list(erlang:size(Data)),
     file:write_file(GUID, Data, [raw, binary]),

--- a/src/services/n2o_secret.erl
+++ b/src/services/n2o_secret.erl
@@ -25,7 +25,7 @@ depickle(PickledData) ->
         Decoded = unhex(iolist_to_binary(PickledData)),
         <<IV:16/binary,Signature:32/binary,Cipher/binary>> = Decoded,
         Signature = mac([application:get_env(n2o,hmac,sha256),Key,<<Cipher/binary,IV/binary>>]),
-        Decipher = case erlang:list_to_integer(erlang:system_info(otp_release)) of
+        _Decipher = case erlang:list_to_integer(erlang:system_info(otp_release)) of
            X when X =< 22 -> binary_to_term(erlang:apply(crypto,block_decrypt,[aes_cbc128,Key,IV,Cipher]),[safe]) ;
            _ -> binary_to_term(erlang:apply(crypto,crypto_one_time,[aes_128_cbc,Key,IV,Cipher,[{encrypt,false}]]),[safe])
        end


### PR DESCRIPTION
```
src/n2o_multipart.erl:21:15: Warning: variable 'Filename' is unused
%   21|     {file, _, Filename, ContentType} = cow_multipart:form_data(Headers),
%     |               ^

src/n2o_multipart.erl:21:25: Warning: variable 'ContentType' is unused
%   21|     {file, _, Filename, ContentType} = cow_multipart:form_data(Headers),
%     |                         ^

src/services/n2o_secret.erl:28:9: Warning: variable 'Decipher' is unused
%   28|         Decipher = case erlang:list_to_integer(erlang:system_info(otp_release)) of
%     |         ^
```